### PR TITLE
QA-235: pipeline: Switch to static checks by golangci-lint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ stages:
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-static.yml'
+    file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-unittests.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -28,9 +28,3 @@ include:
 test:unit:
   variables:
     AZURE_IOT_MANAGER_MONGO: mongo
-
-test:static:
-  image: golangci/golangci-lint:v1.43.0
-  needs: []
-  script:
-    - golangci-lint run -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,4 +43,4 @@ linters-settings:
     # max line length, lines longer will be reported. Default is 120.
     line-length: 100
     # tab width in spaces. Default to 1.
-    tab-width: 8
+    tab-width: 4

--- a/server/server.go
+++ b/server/server.go
@@ -21,8 +21,6 @@ import (
 	"os/signal"
 	"time"
 
-	"github.com/mendersoftware/azure-iot-manager/store"
-
 	"golang.org/x/sys/unix"
 
 	"github.com/mendersoftware/go-lib-micro/config"
@@ -31,6 +29,7 @@ import (
 	api "github.com/mendersoftware/azure-iot-manager/api/http"
 	"github.com/mendersoftware/azure-iot-manager/app"
 	dconfig "github.com/mendersoftware/azure-iot-manager/config"
+	"github.com/mendersoftware/azure-iot-manager/store"
 )
 
 // InitAndRun initializes the server and runs it


### PR DESCRIPTION
Modify the existing .golangci.yml to follow standard and fix one linting
issue.